### PR TITLE
InOutCommon: fix autoReset monotonic timestamps

### DIFF
--- a/modules/misc/in/input_common.c
+++ b/modules/misc/in/input_common.c
@@ -1989,7 +1989,8 @@ static int inputAssemblerThread(void *stateArg) {
 static const UT_icd ut_caerEventPacketHeader_icd = { sizeof(caerEventPacketHeader), NULL, NULL, NULL };
 
 bool caerInputCommonInit(caerModuleData moduleData, int readFd, bool isNetworkStream,
-bool isNetworkMessageBased) {
+			bool isNetworkMessageBased) {
+
 	inputCommonState state = moduleData->moduleState;
 
 	state->parentModule = moduleData;
@@ -2096,6 +2097,11 @@ bool isNetworkMessageBased) {
 
 	// Add config listeners last, to avoid having them dangling if Init doesn't succeed.
 	sshsNodeAddAttributeListener(moduleData->moduleNode, moduleData, &caerInputCommonConfigListener);
+
+	// send TS reset packet (as autoReset will re-start this module -> init will be called again
+	handleTSReset(state);
+	caerLog(CAER_LOG_WARNING, state->parentModule->moduleSubSystemString, "Sending TS_RESET packet from init.");
+
 
 	return (true);
 }

--- a/modules/misc/in/input_common.c
+++ b/modules/misc/in/input_common.c
@@ -2027,7 +2027,9 @@ bool caerInputCommonInit(caerModuleData moduleData, int readFd, bool isNetworkSt
 	state->sourceInfoNode = sshsGetRelativeNode(moduleData->moduleNode, "sourceInfo/");
 	sshsNodePutLongIfAbsent(state->sourceInfoNode, "highestTimestamp", 0);
         sshsNodePutLongIfAbsent(state->sourceInfoNode, "_highestTimestamp", 0); //only set during absolutely 1st run
-	sshsNodePutLongIfAbsent(state->sourceInfoNode, "_lowestTimestamp", INT32_MAX); //high < low -> will be recomputed in 1st iter of run() 
+	sshsNodePutLongIfAbsent(state->sourceInfoNode, "_lowestTimestamp", INT32_MAX); //high < low -> will be recomputed in 1st iter of run()
+        sshsNodePutLongIfAbsent(state->sourceInfoNode, "carryTS", 0); 
+ 
 
 	// Check for invalid file descriptors.
 	if (readFd < -1) {

--- a/modules/misc/in/input_common.c
+++ b/modules/misc/in/input_common.c
@@ -21,7 +21,7 @@
 #include <libcaer/events/polarity.h>
 #include <libcaer/events/frame.h>
 
-#define MAX_HEADER_LINE_SIZE 1024
+const size_t MAX_HEADER_LINE_SIZE = 1024; 
 
 enum input_reader_state {
 	READER_OK = 0, EOF_REACHED = 1, ERROR_READ = -1, ERROR_HEADER = -2, ERROR_DATA = -3,
@@ -297,7 +297,7 @@ static bool parseNetworkHeader(inputCommonState state) {
 
 	// TODO: Network: get sourceInfo node info via config-server side-channel.
 	state->header.sourceID = networkHeader.sourceID;
-	sshsNodePutShort(state->sourceInfoNode, "dvsSizeX", 240);
+	sshsNodePutShort(state->sourceInfoNode, "dvsSizeX", 240); // updated to different HW models in parseSourceString() 
 	sshsNodePutShort(state->sourceInfoNode, "dvsSizeY", 180);
 	sshsNodePutShort(state->sourceInfoNode, "apsSizeX", 240);
 	sshsNodePutShort(state->sourceInfoNode, "apsSizeY", 180);

--- a/modules/misc/in/input_common.c
+++ b/modules/misc/in/input_common.c
@@ -2100,7 +2100,7 @@ bool caerInputCommonInit(caerModuleData moduleData, int readFd, bool isNetworkSt
 
 	// send TS reset packet (as autoReset will re-start this module -> init will be called again
 	handleTSReset(state);
-	caerLog(CAER_LOG_WARNING, state->parentModule->moduleSubSystemString, "Sending TS_RESET packet from init.");
+	caerLog(CAER_LOG_DEBUG, state->parentModule->moduleSubSystemString, "Sending TS_RESET packet from init.");
 
 
 	return (true);
@@ -2209,6 +2209,8 @@ void caerInputCommonRun(caerModuleData moduleData, size_t argsNumber, va_list ar
 
 		sshsNodePutLong(state->sourceInfoNode, "highestTimestamp",
 			caerEventPacketContainerGetHighestEventTimestamp(*container));
+size_t a =caerEventPacketContainerGetHighestEventTimestamp(*container);
+caerLog(CAER_LOG_ERROR, state->parentModule->moduleSubSystemString,"TS= %ul", a);
 
 		caerEventPacketHeader special = caerEventPacketContainerGetEventPacket(*container, SPECIAL_EVENT);
 


### PR DESCRIPTION
`autoReset` option now correctly handles the re-start of the stream by sending a TS_RESET packet as the protocol mandates.
Modules are required to know and handle the TS_RESET situation.

Fixes #44